### PR TITLE
Develop

### DIFF
--- a/src/components/VueBootstrap4Table.vue
+++ b/src/components/VueBootstrap4Table.vue
@@ -173,7 +173,7 @@
                                                     |
                                                 </slot>
                                             </template>
-                                            <template v-if="selected_rows_info">
+                                            <template v-if="selected_rows_info && checkbox_rows">
                                                 <slot name="selected-rows-info" :selectedItemsCount="selectedItemsCount">
                                                     {{selectedItemsCount}} rows selected
                                                 </slot>

--- a/src/components/VueBootstrap4Table.vue
+++ b/src/components/VueBootstrap4Table.vue
@@ -483,20 +483,37 @@ export default {
                 this.sort();
             }
         },
-        isShiftSelection(shiftKey,rowIndex){
-            return (shiftKey == true) && (this.lastSelectedItemIndex != null) && (this.lastSelectedItemIndex != rowIndex);
-        },
         handleAddRow(payload) {
-            let row = this.vbt_rows[payload.rowIndex];
-            if (this.isShiftSelection(payload.shiftKey,payload.rowIndex)) {
-                let rows = this.getShiftSelectionRows(payload.rowIndex);
-                rows.forEach((_row) => {this.addSelectedItem(_row)});
-            } else {
-                this.addSelectedItem(row);
+            if (payload.shiftKey) {
+                this.handleShiftSelection(payload);
+                return;
             }
 
-            this.$emit('on-select-row', {"selected_items":_.cloneDeep(this.selected_items) ,"selected_item":row});
+            let row = this.vbt_rows[payload.rowIndex];
+            this.lastSelectedItemIndex = payload.rowIndex;
+            this.addSelectedItem(row);
+            this.checkAllRowsSelected();
+        },
+        handleRemoveRow(payload) {
+            if (payload.shiftKey) {
+                this.handleShiftSelection(payload);
+                return;
+            }
 
+            let row = this.vbt_rows[payload.rowIndex];
+            this.removeSelectedItem(row);
+            this.allRowsSelected = false;
+        },
+        handleShiftSelection(payload) {
+            let lastSelectedItemIndex = (this.lastSelectedItemIndex != null) ? this.lastSelectedItemIndex : payload.rowIndex;
+            let start = Math.min(this.lastSelectedItemIndex, payload.rowIndex);
+            let end = Math.max(this.lastSelectedItemIndex, payload.rowIndex);
+            let rows = this.vbt_rows.slice(start,end + 1);
+            this.unSelectAllItems();
+            rows.forEach((_row) => {this.addSelectedItem(_row)});
+            this.checkAllRowsSelected();
+        },
+        checkAllRowsSelected() {
             let difference = [];
 
             if (this.server_mode && !this.hasUniqueId) {
@@ -505,31 +522,10 @@ export default {
                 difference = _.differenceBy(this.vbt_rows, this.selected_items, this.uniqueId);
             }
 
-            if (difference.length == 0) {
-                this.allRowsSelected = true;
-                // EventBus.$emit('select-select-all-items-checkbox', "from main");
-            } else {
-                this.allRowsSelected = false;
-                // EventBus.$emit('unselect-select-all-items-checkbox', "from main");
-            }
+            this.allRowsSelected = difference.length == 0;
+        },
 
-            this.lastSelectedItemIndex = payload.rowIndex;
-        },
-        handleRemoveRow(payload) {
-            let row = this.vbt_rows[payload.rowIndex];
-            if (this.isShiftSelection(payload.shiftKey,payload.rowIndex)) {
-                let rows = this.getShiftSelectionRows(payload.rowIndex);
-                rows.forEach((_row) => {this.removeSelectedItem(_row)});
-            } else {
-                this.removeSelectedItem(row);
-            }
-            this.$emit('on-unselect-row', {"selected_items":_.cloneDeep(this.selected_items),"unselected_item":row});
-            // EventBus.$emit('unselect-select-all-items-checkbox');
-            this.allRowsSelected = false;
-            this.lastSelectedItemIndex = payload.rowIndex;
-        },
         addSelectedItem(item) {
-
             let index = -1;
             if (this.server_mode && !this.hasUniqueId) {
                 index = _.findIndex(this.selected_items, (selected_item) => {return _.isEqual(selected_item, item)});
@@ -540,6 +536,8 @@ export default {
             if (index == -1) {
                 this.selected_items.push(item);
             }
+
+            this.$emit('on-select-row', {"selected_items":_.cloneDeep(this.selected_items) ,"selected_item":item});
         },
         selectAllItems() {
 
@@ -582,18 +580,7 @@ export default {
                     return false;
                 }
             });
-        },
-        getShiftSelectionRows(rowIndex) {
-            let start = 0;
-            let end = 0;
-            if (this.lastSelectedItemIndex < rowIndex) {
-                start = this.lastSelectedItemIndex;
-                end = rowIndex + 1;
-            } else if (this.lastSelectedItemIndex > rowIndex) {
-                start = rowIndex;
-                end = this.lastSelectedItemIndex + 1;
-            }
-            return this.vbt_rows.slice(start,end);
+            this.$emit('on-unselect-row', {"selected_items":_.cloneDeep(this.selected_items),"unselected_item":item});
         },
         updateFilter(payload) {
             let event = payload.event;

--- a/src/components/VueBootstrap4Table.vue
+++ b/src/components/VueBootstrap4Table.vue
@@ -506,8 +506,8 @@ export default {
         },
         handleShiftSelection(payload) {
             let lastSelectedItemIndex = (this.lastSelectedItemIndex != null) ? this.lastSelectedItemIndex : payload.rowIndex;
-            let start = Math.min(this.lastSelectedItemIndex, payload.rowIndex);
-            let end = Math.max(this.lastSelectedItemIndex, payload.rowIndex);
+            let start = Math.min(lastSelectedItemIndex, payload.rowIndex);
+            let end = Math.max(lastSelectedItemIndex, payload.rowIndex);
             let rows = this.vbt_rows.slice(start,end + 1);
             this.unSelectAllItems();
             rows.forEach((_row) => {this.addSelectedItem(_row)});


### PR DESCRIPTION
I updated the selection counter to not be shown when select mode is disabled.
Also this changes the shift select feature to behave more like it does on html <select>.
Most importantly the between select is applied between the last selected item when the modifier key was NOT pressed and the selected item now.
Previous selections are now being removed (on the current page) when using the shift select (keeping it could also be an option because it allows for more elaborate selecting).